### PR TITLE
Update assertion of GetFeatureInfo.Valid.InfoFormat

### DIFF
--- a/src/main/scripts/ctl/wmtsFunctions.xml
+++ b/src/main/scripts/ctl/wmtsFunctions.xml
@@ -27837,29 +27837,37 @@ xmlns:wwwFunctions="https://cite.opengeospatial.org/wmts-1.0.0/src/ctl/wwwFuncti
 																</parsers:HTTPParser>
 															</ctl:request>
 														</xsl:variable>
-														<xsl:variable name="content" select="$response/response/content/*"/>
+
+														<xsl:variable name="code" select="$response/response/status/@code"/>
 														<xsl:variable name="contentType" select="$response/response/headers/header[@name='Content-Type']"/>
+														<xsl:variable name="contentLength" select="$response/response/headers/header[@name='Content-Length']"/>
+
+														<!-- ctl:message select="concat(' Code: ', $code)"/ -->
+														<!-- ctl:message select="concat(' Content-Type: ', $contentType)"/ -->
+														<!-- ctl:message select="concat(' Content-Length: ', $contentLength)"/ -->
+
 														<xsl:choose>
-															<xsl:when test="not(exists($content))">
-																<ctl:message select="concat('FAILURE: Missing or invalid response entity ; should have been Feature Info in format ', $infoFormat)"/>
+															<xsl:when test="$code != '200' ">
+																<ctl:message>Response does not contain Status Code 200.</ctl:message>
 																<xsl:text>false|</xsl:text>
 															</xsl:when>
 															<xsl:otherwise>
 																<xsl:choose>
-																	<xsl:when test="string(wwwFunctions:mime-match($contentType, $infoFormat)) = 'true' ">
-																		<ctl:message select="concat('Response entity contentType ', $contentType, ' considered to match infoFormat ', $infoFormat)"/>
+																	<xsl:when test="$contentType != $infoFormat ">
+																		<ctl:message select="concat(' ContentType ', $contentType, ' does not match with InfoFormat ', $infoFormat, ' . ')"/>
+																		<xsl:text>false|</xsl:text>
 																	</xsl:when>
 																	<xsl:otherwise>
-																		<ctl:message select="concat('Failure: Response entity contentType ', $contentType, ' not considered to match infoFormat ', $infoFormat)"/>
-																		<xsl:text>false|</xsl:text>
+																		<xsl:choose>
+																			<xsl:when test="$contentLength &lt;= 1 ">
+																				<ctl:message>Response does not contain any content.</ctl:message>
+																				<xsl:text>false|</xsl:text>
+																			</xsl:when>
+																		</xsl:choose>
 																	</xsl:otherwise>
 																</xsl:choose>
 															</xsl:otherwise>
 														</xsl:choose>
-														<xsl:variable name="code" select="$response/response/status/@code"/>
-														<xsl:if test="$code != '' ">
-															<ctl:message select="concat('HTTP status code ', $code)"/>
-														</xsl:if>
 													</xsl:for-each>
 												</xsl:for-each>
 											</xsl:when>


### PR DESCRIPTION
This Pull Request contains a fix for #10 (not tested by me.). The assertion will ignore the response entity and examine the response headers:
- assert status code = 200 (OK)
- assert Content-Type matches requested format
- assert Content-Length > 0

Same fix like Pull Request https://github.com/opengeospatial/ets-wmts10/pull/7.
