### PR TITLE
Update assertion of GetTile.Valid.Tile.Format

### DIFF
--- a/src/main/scripts/ctl/wmtsFunctions.xml
+++ b/src/main/scripts/ctl/wmtsFunctions.xml
@@ -16394,7 +16394,7 @@ xmlns:wwwFunctions="https://cite.opengeospatial.org/wmts-1.0.0/src/ctl/wwwFuncti
 																		<xsl:text>false|</xsl:text>
 																	</xsl:if>
 																	-->
-																	<xsl:if test="string(wwwFunctions:mime-match($imageFormat, $format)) = 'false' ">
+																	<xsl:if test="not(contains($format, $imageFormat))">
 																		<ctl:message>Error: imageFormat of image != request format</ctl:message>
 																		<xsl:text>false|</xsl:text>
 																	</xsl:if>


### PR DESCRIPTION
This Pull Request contains a fix for #14.

Only `KVP.GetTile.Valid.Tile.Format` was tested with [deegree 3.4-pre15](http://cite.lat-lon.de/deegree-webservices-3.4-pre15/services/wmts?service=WMTS&request=GetCapabilities).

The assertion will will check, if the response image format is like request image format (with `contains`). Now the test is passed while requesting with `image/png8`.
