### PR TITLE
Update incorrect variable name

### DIFF
--- a/src/main/scripts/ctl/wmtsFunctions.xml
+++ b/src/main/scripts/ctl/wmtsFunctions.xml
@@ -18152,7 +18152,7 @@ xmlns:wwwFunctions="https://cite.opengeospatial.org/wmts-1.0.0/src/ctl/wwwFuncti
                           <xsl:variable name="infoFormatPos" select="(count($layer/wmts:InfoFormat) + 1) idiv 2"/>
                           <!-- <ctl:message select="concat('infoFormatPos ', $infoFormatPos)"/> -->
                           <xsl:for-each select="$layer/wmts:InfoFormat[$infoFormatPos]">
-                              <xsl:variable name="format" select="."/>
+                              <xsl:variable name="infoFormat" select="."/>
                               <!-- <ctl:message select="concat('format ', $format)"/> -->
                               <xsl:for-each select="$layer/wmts:InfoFormat">
                                   <xsl:variable name="infoFormat" select="."/>


### PR DESCRIPTION
Bugfix for https://github.com/opengeospatial/ets-wmts10/issues/15.

``` xml
<xsl:variable name="format" select="."/>
```

was used twice. Replaced with

``` xml
<xsl:variable name="infoFormat" select="."/>
```
