### PR TITLE
Update wrong exceptionCode if tile row / col is out of range

### DIFF
--- a/src/main/scripts/ctl/wmtsFunctions.xml
+++ b/src/main/scripts/ctl/wmtsFunctions.xml
@@ -29585,7 +29585,7 @@ xmlns:wwwFunctions="https://cite.opengeospatial.org/wmts-1.0.0/src/ctl/wwwFuncti
 																			<ctl:call-function name="owsFunctions:validateExceptionReport">
 																				<ctl:with-param name="httpParserExceptionReport" select="$response"/>
 																				<ctl:with-param name="exceptionReportSchemaPath" select="$exceptionReportSchemaPath"/>
-																				<ctl:with-param name="exceptionCodes">InvalidParameterValue</ctl:with-param>
+																				<ctl:with-param name="exceptionCodes">TileOutOfRange</ctl:with-param>
 																				<ctl:with-param name="locators">TileRow</ctl:with-param>
 																				<ctl:with-param name="oneOrAll">one</ctl:with-param>
 																				<ctl:with-param name="httpStatusCode">404</ctl:with-param>


### PR DESCRIPTION
Bugfix for #16.

If a tile row / col was out out rage, `ets-wtms10` expected `exceptionCodes = InvalidParameterValue`. I have douple check this issue regarding to the WMTS 1.0.0 spec » table 26 `Exception codes for GetFeatureInfo operation`.

Expected Result `exceptionCodes = TileOutOfRange`. 
