### PR TITLE
rename duplicate function

### DIFF
--- a/src/main/scripts/ctl/wmtsServerCommonOperationsTests.xml
+++ b/src/main/scripts/ctl/wmtsServerCommonOperationsTests.xml
@@ -123,7 +123,7 @@
 			<xsl:when test="$metPrerequisites = 'true' ">
 				<xsl:choose>
 					<xsl:when test="$selected = 'true' ">
-						<ctl:call-function name="wwwFunctions:provokeNotFound">
+						<ctl:call-function name="wwwFunctions:provokeNotExistentService">
 							<ctl:with-param name="capabilitiesURL" select="$capabilitiesURL"/>
 							<ctl:with-param name="method">get</ctl:with-param>
 						</ctl:call-function>

--- a/src/main/scripts/ctl/wwwFunctions.xml
+++ b/src/main/scripts/ctl/wwwFunctions.xml
@@ -125,14 +125,14 @@ MIME parameters don't have to match anymore - see issue 24, MIME type test too s
 		  </ctl:code>
    </ctl:function>
 
-	<ctl:function name="wwwFunctions:provokeNotFound">
+	<ctl:function name="wwwFunctions:provokeNotExistentService">
 		<ctl:param name="capabilitiesURL">/wmts:Capabilities/ows:OperationsMetadata/ows:Operation[@name='GetCapabilities']/ows:DCP/ows:HTTP/ows:Get/@xlink:href</ctl:param>
 		<ctl:param name="method">get|post</ctl:param>
 		<ctl:description>Provoke an HTTP 404 error and test whether the server returns that status code.</ctl:description>
 		<ctl:code>
 			<xsl:value-of select="wwwFunctions:provokeNotFound($capabilitiesURL, $method, '/nonesuch')"/>
 		</ctl:code>
-	</ctl:function>	
+	</ctl:function>
 	
 	<ctl:function name="wwwFunctions:provokeNotFound">
 		<ctl:param name="capabilitiesURL">/wmts:Capabilities/ows:OperationsMetadata/ows:Operation[@name='GetCapabilities']/ows:DCP/ows:HTTP/ows:Get/@xlink:href</ctl:param>


### PR DESCRIPTION
There was a function which references itself:
```xml
	<ctl:function name="wwwFunctions:provokeNotFound">
....
		<ctl:code>
			<xsl:value-of select="wwwFunctions:provokeNotFound($capabilitiesURL, $method, 
...
	</ctl:function>
```

I have renamed the function name from ```wwwFunctions:provokeNotFound``` to ```wwwFunctions:provokeNotExistentService```.